### PR TITLE
Bumped knative chart to 0.3.0 for knative app 0.14.0

### DIFF
--- a/addons/knative/0.14.x/knative-1.yaml
+++ b/addons/knative/0.14.x/knative-1.yaml
@@ -34,7 +34,7 @@ spec:
         enabled: true
         domain: "svc.cluster.local"
         customMetricsApiservice:
-          enabeld: false
+          enabled: false
         namespaceKnativeServing:
           additionalLabels:
             ca.istio.io/override: "true"

--- a/addons/knative/0.14.x/knative-1.yaml
+++ b/addons/knative/0.14.x/knative-1.yaml
@@ -2,8 +2,8 @@ apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: ClusterAddon
 metadata:
   annotations:
-    appversion.kubeaddons.mesosphere.io/knative: 0.7.1
-    catalog.kubeaddons.mesosphere.io/addon-revision: 0.7.1-1
+    appversion.kubeaddons.mesosphere.io/knative: 0.14.0
+    catalog.kubeaddons.mesosphere.io/addon-revision: 0.14.0-1
     values.chart.helm.kubeaddons.mesosphere.io/knative: "https://raw.githubusercontent.com/mesosphere/charts/master/staging/knative/values.yaml"
   labels:
     kubeaddons.mesosphere.io/name: knative
@@ -24,7 +24,7 @@ spec:
   chartReference:
     chart: knative
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.2.0
+    version: 0.3.0
     values: |
       eventing:
         enabled: false
@@ -32,11 +32,9 @@ spec:
         enabled: false
       serving:
         enabled: true
+        domain: "svc.cluster.local"
         customMetricsApiservice:
           enabeld: false
-        gateway:
-          https:
-            enabled: false
         namespaceKnativeServing:
           additionalLabels:
             ca.istio.io/override: "true"

--- a/addons/knative/0.14.x/knative-1.yaml
+++ b/addons/knative/0.14.x/knative-1.yaml
@@ -1,0 +1,42 @@
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  annotations:
+    appversion.kubeaddons.mesosphere.io/knative: 0.7.1
+    catalog.kubeaddons.mesosphere.io/addon-revision: 0.7.1-1
+    values.chart.helm.kubeaddons.mesosphere.io/knative: "https://raw.githubusercontent.com/mesosphere/charts/master/staging/knative/values.yaml"
+  labels:
+    kubeaddons.mesosphere.io/name: knative
+  name: knative
+  namespace: kubeaddons
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: false
+    - name: azure
+      enabled: false
+    - name: docker
+      enabled: false
+    - name: none
+      enabled: false
+  chartReference:
+    chart: knative
+    repo: https://mesosphere.github.io/charts/staging
+    version: 0.2.0
+    values: |
+      eventing:
+        enabled: false
+      eventing-sources:
+        enabled: false
+      serving:
+        enabled: true
+        customMetricsApiservice:
+          enabeld: false
+        gateway:
+          https:
+            enabled: false
+        namespaceKnativeServing:
+          additionalLabels:
+            ca.istio.io/override: "true"


### PR DESCRIPTION
This PR bumps the Knative app to 0.14.x. Specifically,

Knative-serving 0.14.0 https://github.com/knative/serving/releases/tag/v0.14.0
Knative-eventing 0.14.2 https://github.com/knative/eventing/releases/tag/v0.14.2
Knative-sourcing 0.14.1 https://github.com/knative/eventing-contrib/releases/tag/v0.14.1

See https://github.com/mesosphere/charts/pull/582 for details