### PR TITLE
Updating KNative chart to support registriesSkippingTagResolving

### DIFF
--- a/addons/knative/0.14.x/knative-1.yaml
+++ b/addons/knative/0.14.x/knative-1.yaml
@@ -24,7 +24,7 @@ spec:
   chartReference:
     chart: knative
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.3.1
+    version: 0.3.2
     values: |
       eventing:
         enabled: false
@@ -37,3 +37,5 @@ spec:
         namespaceKnativeServing:
           additionalLabels:
             ca.istio.io/override: "true"
+        deployment:
+          registriesSkippingTagResolving: ""

--- a/addons/knative/0.14.x/knative-1.yaml
+++ b/addons/knative/0.14.x/knative-1.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     appversion.kubeaddons.mesosphere.io/knative: 0.14.0
     catalog.kubeaddons.mesosphere.io/addon-revision: 0.14.0-1
-    values.chart.helm.kubeaddons.mesosphere.io/knative: "https://raw.githubusercontent.com/mesosphere/charts/master/staging/knative/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/knative: "https://raw.githubusercontent.com/mesosphere/charts/knative-registry-skipping-tag-resolving/staging/knative/values.yaml"
   labels:
     kubeaddons.mesosphere.io/name: knative
   name: knative

--- a/addons/knative/0.14.x/knative-2.yaml
+++ b/addons/knative/0.14.x/knative-2.yaml
@@ -35,4 +35,4 @@ spec:
         customMetricsApiservice:
           enabled: false
         configDeployment:
-          registriesSkippingTagResolving: ""
+          registriesSkippingTagResolving: "gcr.io,docker.io,mcr.microsoft.com,nvcr.io"

--- a/addons/knative/0.14.x/knative-2.yaml
+++ b/addons/knative/0.14.x/knative-2.yaml
@@ -3,7 +3,7 @@ kind: ClusterAddon
 metadata:
   annotations:
     appversion.kubeaddons.mesosphere.io/knative: 0.14.0
-    catalog.kubeaddons.mesosphere.io/addon-revision: 0.14.0-1
+    catalog.kubeaddons.mesosphere.io/addon-revision: 0.14.0-2
     values.chart.helm.kubeaddons.mesosphere.io/knative: "https://raw.githubusercontent.com/mesosphere/charts/master/staging/knative/values.yaml"
   labels:
     kubeaddons.mesosphere.io/name: knative
@@ -24,7 +24,7 @@ spec:
   chartReference:
     chart: knative
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.3.1
+    version: 0.3.2
     values: |
       eventing:
         enabled: false
@@ -37,3 +37,5 @@ spec:
         namespaceKnativeServing:
           additionalLabels:
             ca.istio.io/override: "true"
+        configDeployment:
+          registriesSkippingTagResolving: ""

--- a/addons/knative/0.14.x/knative-2.yaml
+++ b/addons/knative/0.14.x/knative-2.yaml
@@ -34,8 +34,5 @@ spec:
         enabled: true
         customMetricsApiservice:
           enabled: false
-        namespaceKnativeServing:
-          additionalLabels:
-            ca.istio.io/override: "true"
         configDeployment:
           registriesSkippingTagResolving: ""


### PR DESCRIPTION
### What changes are proposed in this PR
This PR to include changes from https://github.com/mesosphere/charts/pull/775 and support `registriesSkippingTagResolving` configuration property for KNative. Resolves [D2IQ-71478: pods launched by kfserving use image SHA instead of tags](https://jira.d2iq.com/browse/D2IQ-71478).

### How the changes were tested
Manual verification:
- providing the following config in cluster.yaml:
  ```
    - configRepository: https://github.com/mesosphere/kubeaddons-kubeflow
      configVersion: knative-registry-skipping-tag-resolving
      addonsList:
      - name: knative
        enabled: true
        values: |
          serving:
            configDeployment:
              registriesSkippingTagResolving: "gcr.io,docker.io"
  ```
- after the cluster is up
  ```
  $> k get cm config-deployment -n knative-serving -o yaml
  apiVersion: v1
  data:
    _example: |
      ################################
      #                              #
      #    EXAMPLE CONFIGURATION     #
      #                              #
      ################################
  
      # This block is not actually functional configuration,
      # but serves to illustrate the available configuration
      # options and document them in a way that is accessible
      # to users that `kubectl edit` this config map.
      #
      # These sample configuration options may be copied out of
      # this example block and unindented to be in the data block
      # to actually change the configuration.
  
      # List of repositories for which tag to digest resolving should be skipped
      registriesSkippingTagResolving: "ko.local,dev.local"
    queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue:v0.14.0
    registriesSkippingTagResolving: gcr.io,docker.io
  kind: ConfigMap
  metadata:
    creationTimestamp: "2020-09-03T19:28:16Z"
    labels:
      serving.knative.dev/release: v0.14.0
    name: config-deployment
    namespace: knative-serving
  ```
- deploying test kfsvc from e2e tests and verifying no replacement
  ```
  $> k apply -f tests/e2e/test-kfserving/00-install-inference-service.yaml
  
  $> kubectl get pods -l model=kfserving-inf-svc-1 -o jsonpath="{.items[*].spec.containers[*].image}" | tr -s '[[:space:]]' '\n'
  
  gcr.io/kfserving/sklearnserver:v0.3.0
  gcr.io/knative-releases/knative.dev/serving/cmd/queue:v0.14.0
  mesosphere/kubeflow:kfserving-storage-initializer-0.3.0-16d17e9
  docker.io/istio/proxyv2:1.6.4
  ```