### PR TITLE
[KNative] Adding index.docker.io to registriesSkippingTagResolving

### DIFF
--- a/addons/knative/0.14.x/knative-2.yaml
+++ b/addons/knative/0.14.x/knative-2.yaml
@@ -35,4 +35,4 @@ spec:
         customMetricsApiservice:
           enabled: false
         configDeployment:
-          registriesSkippingTagResolving: "gcr.io,docker.io,index.docker.io,registry-1.docker.io,registry.hub.docker.com,mcr.microsoft.com,nvcr.io"
+          registriesSkippingTagResolving: "gcr.io,k8s.gcr.io,docker.io,index.docker.io,registry-1.docker.io,registry.hub.docker.com,quay.io,mcr.microsoft.com,nvcr.io"

--- a/addons/knative/0.14.x/knative-2.yaml
+++ b/addons/knative/0.14.x/knative-2.yaml
@@ -35,4 +35,4 @@ spec:
         customMetricsApiservice:
           enabled: false
         configDeployment:
-          registriesSkippingTagResolving: "gcr.io,docker.io,mcr.microsoft.com,nvcr.io"
+          registriesSkippingTagResolving: "gcr.io,docker.io,index.docker.io,mcr.microsoft.com,nvcr.io"

--- a/addons/knative/0.14.x/knative-2.yaml
+++ b/addons/knative/0.14.x/knative-2.yaml
@@ -35,4 +35,4 @@ spec:
         customMetricsApiservice:
           enabled: false
         configDeployment:
-          registriesSkippingTagResolving: "gcr.io,docker.io,index.docker.io,mcr.microsoft.com,nvcr.io"
+          registriesSkippingTagResolving: "gcr.io,docker.io,index.docker.io,registry-1.docker.io,registry.hub.docker.com,mcr.microsoft.com,nvcr.io"


### PR DESCRIPTION
This PR adds `index.docker.io` to `registriesSkippingTagResolving` defaults.

Discovered during running KFP tutorial:
```
$> kubectl get pods mnist-predictor-default-hs56x-deployment-66f647cb8b-4lc7d -o jsonpath="{.spec.containers[*].image}" | tr '[:space:]' '\n'
index.docker.io/tensorflow/serving@sha256:f7e59a29cbc17a6b507751cddde37bccad4407c05ebf2c13b8e6ccb7d2e9affb
gcr.io/knative-releases/knative.dev/serving/cmd/queue:v0.14.0
mesosphere/kubeflow:kfserving-storage-initializer-0.3.0-16d17e9
docker.io/istio/proxyv2:1.6.8%
```

Applied the following configuration:
```
  - configRepository: https://github.com/mesosphere/kubeaddons-kubeflow
    configVersion: stable-1.17-0.4.3
    addonsList:
    - name: knative
      enabled: true
      values: |
        serving:
            configDeployment:
              registriesSkippingTagResolving: "gcr.io,docker.io,index.docker.io,mcr.microsoft.com,nvcr.io"
```

After applying new config:
```
$> kubectl get pods mnist-predictor-default-75nl7-deployment-7445b47867-kcmnm -o jsonpath="{.spec.containers[*].image}" | tr '[:space:]' '\n'
tensorflow/serving:1.14.0
gcr.io/knative-releases/knative.dev/serving/cmd/queue:v0.14.0
mesosphere/kubeflow:kfserving-storage-initializer-0.3.0-16d17e9
docker.io/istio/proxyv2:1.6.8%
```