### PR TITLE
Upgrading KNative chart to support Helm 3

### DIFF
--- a/addons/knative/0.14.x/knative-3.yaml
+++ b/addons/knative/0.14.x/knative-3.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     appversion.kubeaddons.mesosphere.io/knative: 0.14.0
     catalog.kubeaddons.mesosphere.io/addon-revision: 0.14.0-3
-    values.chart.helm.kubeaddons.mesosphere.io/knative: "https://raw.githubusercontent.com/akirillov/charts/master/staging/knative/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/knative: "https://raw.githubusercontent.com/mesosphere/charts/master/staging/knative/values.yaml"
   labels:
     kubeaddons.mesosphere.io/name: knative
   name: knative
@@ -23,7 +23,7 @@ spec:
       enabled: false
   chartReference:
     chart: knative
-    repo: https://github.com/akirillov/charts/staging
+    repo: https://mesosphere.github.io/charts/staging
     version: 0.3.4
     values: |
       eventing:

--- a/addons/knative/0.14.x/knative-3.yaml
+++ b/addons/knative/0.14.x/knative-3.yaml
@@ -1,0 +1,38 @@
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  annotations:
+    appversion.kubeaddons.mesosphere.io/knative: 0.14.0
+    catalog.kubeaddons.mesosphere.io/addon-revision: 0.14.0-3
+    values.chart.helm.kubeaddons.mesosphere.io/knative: "https://raw.githubusercontent.com/mesosphere/charts/master/staging/knative/values.yaml"
+  labels:
+    kubeaddons.mesosphere.io/name: knative
+  name: knative
+  namespace: kubeaddons
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: false
+    - name: azure
+      enabled: false
+    - name: docker
+      enabled: false
+    - name: none
+      enabled: false
+  chartReference:
+    chart: knative
+    repo: https://mesosphere.github.io/charts/staging
+    version: 0.3.3
+    values: |
+      eventing:
+        enabled: false
+      eventing-sources:
+        enabled: false
+      serving:
+        enabled: true
+        customMetricsApiservice:
+          enabled: false
+        configDeployment:
+          registriesSkippingTagResolving: "gcr.io,k8s.gcr.io,docker.io,index.docker.io,registry-1.docker.io,registry.hub.docker.com,quay.io,mcr.microsoft.com,nvcr.io"

--- a/addons/knative/0.14.x/knative-3.yaml
+++ b/addons/knative/0.14.x/knative-3.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     appversion.kubeaddons.mesosphere.io/knative: 0.14.0
     catalog.kubeaddons.mesosphere.io/addon-revision: 0.14.0-3
-    values.chart.helm.kubeaddons.mesosphere.io/knative: "https://raw.githubusercontent.com/mesosphere/charts/master/staging/knative/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/knative: "https://raw.githubusercontent.com/akirillov/charts/master/staging/knative/values.yaml"
   labels:
     kubeaddons.mesosphere.io/name: knative
   name: knative
@@ -23,8 +23,8 @@ spec:
       enabled: false
   chartReference:
     chart: knative
-    repo: https://mesosphere.github.io/charts/staging
-    version: 0.3.3
+    repo: https://github.com/akirillov/charts/staging
+    version: 0.3.4
     values: |
       eventing:
         enabled: false


### PR DESCRIPTION
This PR upgrades KNative chart version to support Helm 3 and include changes introduced in https://github.com/mesosphere/charts/pull/834 and https://github.com/mesosphere/charts/pull/838.