### PR TITLE
[chore] Upgrade knative serving 0.18.3

### DIFF
--- a/addons/knative/0.18.x/knative-1.yaml
+++ b/addons/knative/0.18.x/knative-1.yaml
@@ -23,7 +23,7 @@ spec:
       enabled: false
   chartReference:
     chart: knative
-    repo: https://akirillov.github.io/charts/staging
+    repo: https://mesosphere.github.io/charts/staging
     version: 0.3.5
     values: |
       eventing:

--- a/addons/knative/0.18.x/knative-1.yaml
+++ b/addons/knative/0.18.x/knative-1.yaml
@@ -23,7 +23,7 @@ spec:
       enabled: false
   chartReference:
     chart: knative
-    repo: https://github.com/mesosphere/charts/tree/upgrade-knnative-serving-0.18.3/staging
+    repo: https://akirillov.github.io/charts/staging
     version: 0.3.5
     values: |
       eventing:

--- a/addons/knative/0.18.x/knative-1.yaml
+++ b/addons/knative/0.18.x/knative-1.yaml
@@ -37,3 +37,5 @@ spec:
         namespaceKnativeServing:
           additionalLabels:
             ca.istio.io/override: "true"
+        configDeployment:
+          registriesSkippingTagResolving: "gcr.io,k8s.gcr.io,docker.io,index.docker.io,registry-1.docker.io,registry.hub.docker.com,quay.io,mcr.microsoft.com,nvcr.io,public.ecr.aws"

--- a/addons/knative/0.18.x/knative-1.yaml
+++ b/addons/knative/0.18.x/knative-1.yaml
@@ -1,0 +1,39 @@
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  annotations:
+    appversion.kubeaddons.mesosphere.io/knative: 0.18.3
+    catalog.kubeaddons.mesosphere.io/addon-revision: 0.18.3-1
+    values.chart.helm.kubeaddons.mesosphere.io/knative: "https://raw.githubusercontent.com/mesosphere/charts/master/staging/knative/values.yaml"
+  labels:
+    kubeaddons.mesosphere.io/name: knative
+  name: knative
+  namespace: kubeaddons
+spec:
+  kubernetes:
+    minSupportedVersion: v1.17.0
+  cloudProvider:
+    - name: aws
+      enabled: false
+    - name: azure
+      enabled: false
+    - name: docker
+      enabled: false
+    - name: none
+      enabled: false
+  chartReference:
+    chart: knative
+    repo: https://github.com/mesosphere/charts/tree/upgrade-knnative-serving-0.18.3/staging
+    version: 0.3.5
+    values: |
+      eventing:
+        enabled: false
+      eventing-sources:
+        enabled: false
+      serving:
+        enabled: true
+        customMetricsApiservice:
+          enabled: false
+        namespaceKnativeServing:
+          additionalLabels:
+            ca.istio.io/override: "true"


### PR DESCRIPTION
This PR adds a new version of the Kaptain addon pointing to the changes introduced in https://github.com/mesosphere/charts/pull/1147. The `chartReference.repo` will be updated to point to `mesosphere/charts` once https://github.com/mesosphere/charts/pull/1147 is merged.