### PR TITLE
Expose cofiguration settings for KNative garbage collection

### DIFF
--- a/addons/knative/0.18.x/knative-2.yaml
+++ b/addons/knative/0.18.x/knative-2.yaml
@@ -23,8 +23,8 @@ spec:
       enabled: false
   chartReference:
     chart: knative
-    repo: https://mesosphere.github.io/charts/staging
-    version: 0.3.6
+    repo: https://akirillov.github.io/charts/staging
+    version: 0.3.7
     values: |
       eventing:
         enabled: false
@@ -40,7 +40,8 @@ spec:
         configDeployment:
           registriesSkippingTagResolving: "gcr.io,k8s.gcr.io,docker.io,index.docker.io,registry-1.docker.io,registry.hub.docker.com,quay.io,mcr.microsoft.com,nvcr.io,public.ecr.aws"
         gc:
-          staleRevisionCreateDelay: "48h"
-          staleRevisionTimeout: "15h"
-          staleRevisionMinimumGenerations: "20"
-          staleRevisionLastpinnedDebounce: "5h"
+          responsiveRevisionGC: "allowed"
+          retainSinceCreateTime: "48h"
+          retainSinceLastActiveTime: "15h"
+          minNonActiveRevisions: "20"
+          maxNonActiveRevisions: "1000"

--- a/addons/knative/0.18.x/knative-2.yaml
+++ b/addons/knative/0.18.x/knative-2.yaml
@@ -23,7 +23,7 @@ spec:
       enabled: false
   chartReference:
     chart: knative
-    repo: https://akirillov.github.io/charts/staging
+    repo: https://mesosphere.github.io/charts/staging
     version: 0.3.7
     values: |
       eventing:

--- a/addons/knative/0.18.x/knative-2.yaml
+++ b/addons/knative/0.18.x/knative-2.yaml
@@ -1,0 +1,46 @@
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  annotations:
+    appversion.kubeaddons.mesosphere.io/knative: 0.18.3
+    catalog.kubeaddons.mesosphere.io/addon-revision: 0.18.3-1
+    values.chart.helm.kubeaddons.mesosphere.io/knative: "https://raw.githubusercontent.com/mesosphere/charts/master/staging/knative/values.yaml"
+  labels:
+    kubeaddons.mesosphere.io/name: knative
+  name: knative
+  namespace: kubeaddons
+spec:
+  kubernetes:
+    minSupportedVersion: v1.17.0
+  cloudProvider:
+    - name: aws
+      enabled: false
+    - name: azure
+      enabled: false
+    - name: docker
+      enabled: false
+    - name: none
+      enabled: false
+  chartReference:
+    chart: knative
+    repo: https://mesosphere.github.io/charts/staging
+    version: 0.3.6
+    values: |
+      eventing:
+        enabled: false
+      eventing-sources:
+        enabled: false
+      serving:
+        enabled: true
+        customMetricsApiservice:
+          enabled: false
+        namespaceKnativeServing:
+          additionalLabels:
+            ca.istio.io/override: "true"
+        configDeployment:
+          registriesSkippingTagResolving: "gcr.io,k8s.gcr.io,docker.io,index.docker.io,registry-1.docker.io,registry.hub.docker.com,quay.io,mcr.microsoft.com,nvcr.io,public.ecr.aws"
+        gc:
+          staleRevisionCreateDelay: "48h"
+          staleRevisionTimeout: "15h"
+          staleRevisionMinimumGenerations: "20"
+          staleRevisionLastpinnedDebounce: "5h"

--- a/addons/knative/0.18.x/knative-2.yaml
+++ b/addons/knative/0.18.x/knative-2.yaml
@@ -3,7 +3,7 @@ kind: ClusterAddon
 metadata:
   annotations:
     appversion.kubeaddons.mesosphere.io/knative: 0.18.3
-    catalog.kubeaddons.mesosphere.io/addon-revision: 0.18.3-1
+    catalog.kubeaddons.mesosphere.io/addon-revision: 0.18.3-2
     values.chart.helm.kubeaddons.mesosphere.io/knative: "https://raw.githubusercontent.com/mesosphere/charts/master/staging/knative/values.yaml"
   labels:
     kubeaddons.mesosphere.io/name: knative


### PR DESCRIPTION
**What this PR does/ why we need it**:
This PR adds template parameters to expose the garbage collection configuration for Knative Addon.
See [D2IQ-77479: Expose KNative Serving GC configuration in the addon](https://jira.d2iq.com/browse/D2IQ-77479) for additional background.